### PR TITLE
compat: enable mod-added recipes on disabled technology

### DIFF
--- a/src/data-final-fixes/technology.ts
+++ b/src/data-final-fixes/technology.ts
@@ -1,14 +1,43 @@
+import { listHiddenRecipes } from 'src/utils/item';
 import { listHiddenTechs, removePrerequisite } from 'src/utils/technology';
 
-// Find any techs that depend on ones we removed and make the removed tech no longer a dependency
 const hiddenTechs = listHiddenTechs();
+const hiddenRecipes = listHiddenRecipes();
 
+// Find any techs that depend on ones we removed and make the removed tech no longer a dependency
 for(const [i, technology] of pairs(data.raw.technology)) {
     if(technology.prerequisites) {
         for(let tech of hiddenTechs) {
             for(let prerequisite of technology.prerequisites) {
                 if(prerequisite === tech) {
                     removePrerequisite(technology.name, prerequisite);
+                }
+            }
+        }
+    }
+}
+
+// If any hidden techs contain items that were not intentionally hidden, enable them
+// Anything we're hiding intentionally should have its items/recipes handled manually
+// So this probably means another mod added a recipe to a tech we're hiding (i.e. Age of Production adds wooden planks to tree seeding)
+// This might enable some recipes earlier than they should be, but without this step the recipe would just be lost/inaccessible.
+for(const hiddenTech of hiddenTechs) {
+    const technology = data.raw.technology[hiddenTech];
+
+    if(technology.effects) {
+        for(const [index, effect] of pairs(technology.effects)) {
+            const effectModifier = effect as prototype.Modifier;
+            if(effectModifier.type === 'unlock-recipe')
+            {
+                let isHiddenRecipe = false;
+                for(const recipe of hiddenRecipes)
+                {
+                    if(effectModifier.recipe === recipe) {
+                        isHiddenRecipe = true;
+                    }
+                }
+                if(!isHiddenRecipe) {
+                    data.raw.recipe[effectModifier.recipe].enabled = true;
                 }
             }
         }

--- a/src/data-updates/hidden-items.ts
+++ b/src/data-updates/hidden-items.ts
@@ -1,44 +1,26 @@
 import { addHiddenEntity } from 'src/utils/entity';
 import { settingKeys } from '../setting-keys';
-
-let hiddenItems: string[] = [];
+import { hideItem } from 'src/utils/item';
 
 if(settings.startup[settingKeys.disableMiningDrills].value) {
-    table.insert(hiddenItems, 'burner-mining-drill');
+    hideItem('burner-mining-drill');
     addHiddenEntity(data.raw['mining-drill']['burner-mining-drill']);
-    table.insert(hiddenItems, 'electric-mining-drill');
+    hideItem('electric-mining-drill');
     addHiddenEntity(data.raw['mining-drill']['electric-mining-drill']);
-    table.insert(hiddenItems, 'big-mining-drill');
+    hideItem('big-mining-drill');
     addHiddenEntity(data.raw['mining-drill']['big-mining-drill']);
 }
 
 if(settings.startup[settingKeys.disablePumpjacks].value) {
-    table.insert(hiddenItems, 'pumpjack');
+    hideItem('pumpjack');
     addHiddenEntity(data.raw['mining-drill']['pumpjack']);
 }
 
 if(settings.startup[settingKeys.disableOvergrowthSoil].value) {
-    table.insert(hiddenItems, 'overgrowth-jellynut-soil');
-    table.insert(hiddenItems, 'overgrowth-yumako-soil');
+    hideItem('overgrowth-jellynut-soil');
+    hideItem('overgrowth-yumako-soil');
 }
 
 if(settings.startup[settingKeys.disableCliffExplosives].value) {
-    table.insert(hiddenItems, 'cliff-explosives');
-}
-
-for(let itemName of hiddenItems) {
-    let item = data.raw.item[itemName];
-    if(item) {
-        item.flags ||= [];
-        item.hidden = true;
-    }
-    let fluid = data.raw.fluid[itemName];
-    if(fluid) {
-        fluid.hidden = true;
-    }
-    let recipe = data.raw.recipe[itemName];
-    if(recipe) {
-        recipe.enabled = false;
-        recipe.hidden = true;
-    }
+    hideItem('cliff-explosives');
 }

--- a/src/mod-compat/data-updates/k2so.ts
+++ b/src/mod-compat/data-updates/k2so.ts
@@ -1,5 +1,6 @@
 import { settingKeys } from 'src/setting-keys';
 import { addHiddenEntity } from 'src/utils/entity';
+import { hideItem } from 'src/utils/item';
 import { addStartingItems } from 'src/utils/starting-items';
 import { addMiningProductivity, addPrerequisite, hideTechnology, removePrerequisite, removeSciencePack, techAddRecipe, techRemoveRecipe } from 'src/utils/technology';
 
@@ -14,10 +15,8 @@ if(mods['Krastorio2'])
 
     if(settings.startup[settingKeys.disableMiningDrills].value) {
         hideTechnology('kr-electric-mining-drill-mk2');
-        data.raw.item['kr-electric-mining-drill-mk2'].flags ||= [];
-        data.raw.item['kr-electric-mining-drill-mk2'].hidden = true;
-        data.raw.item['kr-quarry-drill'].flags ||= [];
-        data.raw.item['kr-quarry-drill'].hidden = true;
+        hideItem('kr-electric-mining-drill-mk2');
+        hideItem('kr-quarry-drill');
 
         addHiddenEntity(data.raw['mining-drill']['kr-electric-mining-drill-mk2']);
 

--- a/src/utils/item.ts
+++ b/src/utils/item.ts
@@ -1,0 +1,31 @@
+const hiddenItems: string[] = [];
+const hiddenRecipes: string[] = [];
+
+export function hideItem(itemName: string)
+{
+    let item = data.raw.item[itemName];
+    if(item) {
+        item.flags ||= [];
+        item.hidden = true;
+        hiddenItems.push(itemName);
+    }
+    // Not currently hiding any fluids, re-visit later if needed
+    // let fluid = data.raw.fluid[itemName];
+    // if(fluid) {
+    //     fluid.hidden = true;
+    // }
+    let recipe = data.raw.recipe[itemName];
+    if(recipe) {
+        recipe.enabled = false;
+        recipe.hidden = true;
+        hiddenRecipes.push(itemName);
+    }
+}
+
+export function listHiddenItems() {
+    return hiddenItems;
+}
+
+export function listHiddenRecipes() {
+    return hiddenRecipes;
+}


### PR DESCRIPTION
Compatibility improvement for cases where other mods add recipes to techs that have been disabled

Case that prompted this is Age of Production adding a new Wood Planks recipe to the Tree Seeding research, which is disabled in Simple Seablock since normally it only gives Wood Processing, which is given to the user automatically.

This may end up with recipes being enabled before they really should be, but the alternative is these recipes are simply inaccessible and lost. Can add per-mod compatibility in cases where this is game-breaking. Recipes that this mod has intentionally disabled will not be enabled by this new compat layer.